### PR TITLE
Fixed toggling: unmap, restore state for unite

### DIFF
--- a/plugin/vim_mlh.vim
+++ b/plugin/vim_mlh.vim
@@ -67,17 +67,20 @@ function! s:unmapMlh()
     let g:vim_mlh_enable = 0
     try
         iunmap /<Space>
-        iunmap //<Space> //<Space>
+        iunmap //<Space>
     catch
     endtry
 endfun
 
+let g:_vim_mlh_disabled_for_unite = 0
 function! s:autoCmdToggleMlh()
-    if &filetype == 'unite'
+    if &filetype == 'unite' && g:vim_mlh_enable != 0
+        let g:_vim_mlh_disabled_for_unite = 1
         call <SID>unmapMlh()
-        return
+    elseif g:_vim_mlh_disabled_for_unite != 0
+        call <SID>mapMlh()
+        let g:_vim_mlh_disabled_for_unite = 0
     endif
-    call <SID>mapMlh()
 endf
 
 "" Define augroup {{{2


### PR DESCRIPTION
#### Unexpectedly re-enabled when switch to insert mode with toggle disabled.

The code was re-enabling toggle without checking previous toggle state when buffer is not unite.
I added state to check whether previous buffer is unite with toggle enabled.
#### Inputing slash would be freeze (wating keystroke) with toggle disabled.

iunmap for //<Space> not working because there is garbage on that command.
I removed that garbage from code.
