### PR TITLE
Fix duplicate tag due to notation mistake

### DIFF
--- a/doc/vim-mlh.txt
+++ b/doc/vim-mlh.txt
@@ -26,14 +26,14 @@ License : MIT license {{{
 ==============================================================================
 CONTENTS					*vim-mlh-contents*
 
-INTRODUCTION					*vim-mlh-introduction*
- CONVERT_CHARACTERS					*vim-mlh-convert_characters*
-REQUREMENT					*vim-mlh-requirement*
-INTERFACE					*vim-mlh-interface*
- KEY MAPPINGS					*vim-mlh-key-mappings*
- MAPPING EXAMPLE				*vim-mlh-mapping-example*
-SEE ALSO					*vim-mlh-seealso*
-CHANGELOG					*vim-mlh-changelog*
+INTRODUCTION					|vim-mlh-introduction|
+ CONVERT_CHARACTERS					|vim-mlh-convert_characters|
+REQUREMENT					|vim-mlh-requirement|
+INTERFACE					|vim-mlh-interface|
+ KEY MAPPINGS					|vim-mlh-key-mappings|
+ MAPPING EXAMPLE				|vim-mlh-mapping-example|
+SEE ALSO					|vim-mlh-seealso|
+CHANGELOG					|vim-mlh-changelog|
 
 ==============================================================================
 INTRODUCTION					*vim-mlh-introduction*


### PR DESCRIPTION
Error 
```
[dein] Vim(helptags):E154: Duplicate tag "vim-mlh-changelog" in file /Users/dionore/.vim/bundle/.cache/.vimrc/.dein/doc/vim-mlh.txt
[dein] function dein#install[1]..dein#install#_update[35]..<SNR>9_update_loop[5]..<SNR>9_install_async[9]..<SNR>9_done[7]..dein#install#_recache_runtimepath[20]..<SNR>9_helptags, line 12
```